### PR TITLE
Add example to change caps lock to left control

### DIFF
--- a/examples/change_caps_lock_to_left_control.json
+++ b/examples/change_caps_lock_to_left_control.json
@@ -1,0 +1,11 @@
+{
+    "profiles": [
+        {
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": {
+                "caps_lock": "left_control"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
*Modifier Keys...* option in macOS's keyboard settings doesn't work for me, so I create this configuration.

I think it's a common use case for programmers.