### PR TITLE
Mapping PC keyboard layout to Mac keys example

### DIFF
--- a/examples/pc_keyboard_to_mac_mappings.json
+++ b/examples/pc_keyboard_to_mac_mappings.json
@@ -1,0 +1,27 @@
+{
+    "profiles": [
+        {
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": {
+                "f1": "vk_consumer_brightness_down",
+                "f2": "vk_consumer_brightness_up",
+                "f3": "vk_mission_control",
+                "f4": "vk_launchpad",
+                "f5": "vk_consumer_illumination_down",
+                "f6": "vk_consumer_illumination_up",
+                "f7": "vk_consumer_previous",
+                "f8": "vk_consumer_play",
+                "f9": "vk_consumer_next",
+                "f10": "mute",
+                "f11": "volume_up",
+                "f12": "volume_down",
+                "application": "fn",
+                "left_option": "left_command",
+                "left_command": "left_option",
+                "right_command": "right_option",
+                "right_option": "right_command"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Mapping PC keyboard layout to Mac keys. Function keys are mapped to mac media keys and command and options are swapped. For Mac users using PC layout keyboards.