### PR TITLE
Use xdg config home convention

### DIFF
--- a/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
+++ b/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
@@ -312,15 +312,15 @@
                         <tabViewItems>
                             <tabViewItem label="Simple Modifications" identifier="1" id="SOT-pf-9fT">
                                 <view key="view" id="aYZ-Ew-w2F">
-                                    <rect key="frame" x="10" y="33" width="554" height="298"/>
+                                    <rect key="frame" x="10" y="33" width="754" height="438"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0WE-kI-jqf">
-                                            <rect key="frame" x="193" y="202" width="368" height="34"/>
+                                            <rect key="frame" x="102" y="202" width="551" height="34"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="uVC-62-ghX">
                                                 <font key="font" metaFont="system"/>
                                                 <string key="title">You will be able to change keys in this pane.
-Please modify karabiner.json by a text editor at the moment.</string>
+Please modify  ~/.config/karabiner-elements/karabiner.json by a text editor at the moment.</string>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -350,11 +350,11 @@ Please modify karabiner.json by a text editor at the moment.</string>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="srp-gY-aJd">
-                                            <rect key="frame" x="170" y="202" width="414" height="34"/>
+                                            <rect key="frame" x="102" y="202" width="551" height="34"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="2O9-UT-lW5">
                                                 <font key="font" metaFont="system"/>
                                                 <string key="title">You will be able to map media controls to function keys in this pane.
-Please modify karabiner.json by a text editor at the moment.</string>
+Please modify  ~/.config/karabiner-elements/karabiner.json by a text editor at the moment.</string>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>

--- a/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
+++ b/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
@@ -570,7 +570,7 @@ Please modify karabiner.json by a text editor at the moment.</string>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O5H-Qe-BvI">
                                             <rect key="frame" x="15" y="194" width="280" height="17"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="~/.karabiner.d/log/console_user_server_log.txt" id="byo-Qj-XKk">
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="~/Library/Logs/Karabiner-Elements/console_user_server_log.txt" id="byo-Qj-XKk">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/src/apps/PreferencesWindow/PreferencesWindow/PreferencesWindowController.m
+++ b/src/apps/PreferencesWindow/PreferencesWindow/PreferencesWindowController.m
@@ -16,7 +16,9 @@
   self.versionLabel.stringValue = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
 
   [self.grabberLogFileTextViewController monitor:@"/var/log/karabiner/grabber_log.txt"];
-  [self.consoleUserServerLogFileTextViewController monitor:[NSString stringWithFormat:@"%@/.karabiner.d/log/console_user_server_log.txt", NSHomeDirectory()]];
+  NSString* logPath = [NSString stringWithFormat:@"%@/Library/Logs/Karabiner-Elements/console_user_server_log.txt",
+                       NSHomeDirectory()];
+  [self.consoleUserServerLogFileTextViewController monitor:logPath];
 
   [self launchctlConsoleUserServer:YES];
 }

--- a/src/core/console_user_server/include/logger.hpp
+++ b/src/core/console_user_server/include/logger.hpp
@@ -11,11 +11,8 @@ public:
   static spdlog::logger& get_logger(void) {
     static std::shared_ptr<spdlog::logger> logger;
     if (!logger) {
-      if (auto p = constants::get_home_dot_karabiner_directory()) {
+      if (auto p = constants::get_logging_directory()) {
         std::string log_directory = p;
-        mkdir(log_directory.c_str(), 0700);
-
-        log_directory += "/log/";
         mkdir(log_directory.c_str(), 0700);
 
         if (filesystem::is_directory(log_directory)) {

--- a/src/share/constants.hpp
+++ b/src/share/constants.hpp
@@ -32,7 +32,10 @@ public:
 
     if (!once) {
       once = true;
-      if (auto p = std::getenv("HOME")) {
+      if (auto x = std::getenv("XDG_CONFIG_HOME")) {
+        directory = x;
+        directory += "/karabiner-elements";
+      } else if (auto p = std::getenv("HOME")) {
         directory = p;
         directory += "/.config/karabiner-elements";
       }

--- a/src/share/constants.hpp
+++ b/src/share/constants.hpp
@@ -23,7 +23,7 @@ public:
     return "/Library/Application Support/org.pqrs/tmp/karabiner_event_dispatcher_receiver";
   }
 
-  static const char* get_home_dot_karabiner_directory(void) {
+  static const char* get_configuration_directory(void) {
     static std::mutex mutex;
     static bool once = false;
     static std::string directory;
@@ -34,7 +34,7 @@ public:
       once = true;
       if (auto p = std::getenv("HOME")) {
         directory = p;
-        directory += "/.karabiner.d";
+        directory += "/.config/karabiner-elements";
       }
     }
 
@@ -45,7 +45,7 @@ public:
     }
   }
 
-  static const char* get_configuration_directory(void) {
+  static const char* get_logging_directory(void) {
     static std::mutex mutex;
     static bool once = false;
     static std::string directory;
@@ -54,9 +54,9 @@ public:
 
     if (!once) {
       once = true;
-      if (auto p = get_home_dot_karabiner_directory()) {
+      if (auto p = std::getenv("HOME")) {
         directory = p;
-        directory += "/configuration";
+        directory += "/Library/Logs/Karabiner-Elements";
       }
     }
 

--- a/src/share/file_monitor.hpp
+++ b/src/share/file_monitor.hpp
@@ -60,7 +60,6 @@ private:
     // $ mkdir ~/.config/karabiner-elements
     // $ touch ~/.config/karabiner-elements/xxx.json
     // $ mv ~/.config/karabiner-elements ~/.config/karabiner-elements.back
-    // $ ln -s ~/file-synchronisation-service/karabiner.d/configuration ~/.karabiner.d/
     // $ touch ~/.config/karabiner-elements/xxx.json
 
     auto flags = FSEventStreamCreateFlags(0);

--- a/src/share/file_monitor.hpp
+++ b/src/share/file_monitor.hpp
@@ -55,13 +55,13 @@ private:
     context.info = this;
 
     // kFSEventStreamCreateFlagWatchRoot and kFSEventStreamCreateFlagFileEvents are required in the following case.
-    // (When directory == ~/.karabiner.d/configuration, file == ~/.karabiner.d/configuration/xxx.json)
+    // (When directory == ~/.config/karabiner-elements, file == ~/.config/karabiner-elements/xxx.json)
     //
-    // $ mkdir ~/.karabiner.d/configuration
-    // $ touch ~/.karabiner.d/configuration/xxx.json
-    // $ mv ~/.karabiner.d/configuration ~/.karabiner.d/configuration.back
+    // $ mkdir ~/.config/karabiner-elements
+    // $ touch ~/.config/karabiner-elements/xxx.json
+    // $ mv ~/.config/karabiner-elements ~/.config/karabiner-elements.back
     // $ ln -s ~/file-synchronisation-service/karabiner.d/configuration ~/.karabiner.d/
-    // $ touch ~/.karabiner.d/configuration/xxx.json
+    // $ touch ~/.config/karabiner-elements/xxx.json
 
     auto flags = FSEventStreamCreateFlags(0);
     flags |= kFSEventStreamCreateFlagWatchRoot;

--- a/usage/README.md
+++ b/usage/README.md
@@ -38,7 +38,7 @@ You can uninstall Karabiner-Elements from Misc tab.
 
 At the moment, you have to edit the configuration file by hand.
 
-The configuration file is located in `~/.karabiner.d/configuration/karabiner.json`
+The configuration file is located in `~/.config/karabiner-elements/karabiner.json`
 
 ## An example of karabiner.json
 
@@ -67,32 +67,32 @@ The configuration file is located in `~/.karabiner.d/configuration/karabiner.jso
 If you want change caps lock to delete key, execute the following commands in Terminal.
 
 ```shell
-mkdir -p ~/.karabiner.d/configuration/
-cd ~/.karabiner.d/configuration/
+mkdir -p ~/.config/karabiner-elements/
+cd ~/.config/karabiner-elements/
 curl -L -o karabiner.json https://raw.githubusercontent.com/tekezo/Karabiner-Elements/master/examples/change_caps_lock_to_delete.json
 ```
 
 ### change caps lock to escape
 
 ```shell
-mkdir -p ~/.karabiner.d/configuration/
-cd ~/.karabiner.d/configuration/
+mkdir -p ~/.config/karabiner-elements/
+cd ~/.config/karabiner-elements/
 curl -L -o karabiner.json https://raw.githubusercontent.com/tekezo/Karabiner-Elements/master/examples/change_caps_lock_to_escape.json
 ```
 
 ### swap caps lock and delete
 
 ```shell
-mkdir -p ~/.karabiner.d/configuration/
-cd ~/.karabiner.d/configuration/
+mkdir -p ~/.config/karabiner-elements/
+cd ~/.config/karabiner-elements/
 curl -L -o karabiner.json https://raw.githubusercontent.com/tekezo/Karabiner-Elements/master/examples/swap_caps_lock_and_delete.json
 ```
 
 ### swap caps lock and escape
 
 ```shell
-mkdir -p ~/.karabiner.d/configuration/
-cd ~/.karabiner.d/configuration/
+mkdir -p ~/.config/karabiner-elements/
+cd ~/.config/karabiner-elements/
 curl -L -o karabiner.json https://raw.githubusercontent.com/tekezo/Karabiner-Elements/master/examples/swap_caps_lock_and_escape.json
 ```
 


### PR DESCRIPTION
Implementation for https://github.com/tekezo/Karabiner-Elements/issues/112 where the config files live under `~/.config/karabiner-elements` instead of `~/.karabiner.d/configuration`.
