### PR TITLE
add hyper key

### DIFF
--- a/src/apps/PreferencesWindow/PreferencesWindow/Resources/simple_modifications.json
+++ b/src/apps/PreferencesWindow/PreferencesWindow/Resources/simple_modifications.json
@@ -21,6 +21,8 @@
 }, {
     "name": "fn"
 }, {
+    "name": "hyper"
+}, {
     "category": "Controls and symbols"
 }, {
     "name": "return_or_enter"

--- a/src/core/grabber/include/manipulator/modifier_flag_manager.hpp
+++ b/src/core/grabber/include/manipulator/modifier_flag_manager.hpp
@@ -21,6 +21,7 @@ public:
     states_[static_cast<size_t>(krbn::modifier_flag::right_option)] = std::make_unique<state>("option", "⌥");
     states_[static_cast<size_t>(krbn::modifier_flag::right_command)] = std::make_unique<state>("command", "⌘");
     states_[static_cast<size_t>(krbn::modifier_flag::fn)] = std::make_unique<state>("fn", "fn");
+    states_[static_cast<size_t>(krbn::modifier_flag::hyper)] = std::make_unique<state>("hyper", "hyper");
   }
 
   void reset(void) {
@@ -119,6 +120,9 @@ public:
     if (pressed(krbn::modifier_flag::right_command)) {
       bits |= (0x1 << 7);
     }
+    if (pressed(krbn::modifier_flag::hyper)) {
+      bits |= (0x1 << 0) | (0x1 << 2) | (0x1 << 3);
+    }
 
     return bits;
   }
@@ -153,6 +157,9 @@ public:
     }
     if (pressed(krbn::modifier_flag::right_command)) {
       bits |= NX_COMMANDMASK | NX_DEVICERCMDKEYMASK;
+    }
+    if (pressed(krbn::modifier_flag::hyper)) {
+      bits |= NX_CONTROLMASK | NX_ALTERNATEMASK | NX_COMMANDMASK;
     }
     if (pressed(krbn::modifier_flag::fn)) {
       bits |= NX_SECONDARYFNMASK;

--- a/src/share/types.hpp
+++ b/src/share/types.hpp
@@ -118,6 +118,7 @@ enum class key_code : uint32_t {
   // predefined virtual modifier flags
   vk_none,
   vk_fn_modifier,
+  vk_hyper_modifier,
 
   // virtual key codes
   vk_consumer_brightness_down,
@@ -195,6 +196,7 @@ enum class modifier_flag : uint32_t {
   right_option,
   right_command,
   fn,
+  hyper,
   prepared_modifier_flag_end_
 };
 
@@ -254,6 +256,8 @@ public:
       return modifier_flag::right_command;
     case static_cast<uint32_t>(key_code::vk_fn_modifier):
       return modifier_flag::fn;
+    case static_cast<uint32_t>(key_code::vk_hyper_modifier):
+      return modifier_flag::hyper;
     default:
       return modifier_flag::zero;
     }
@@ -449,6 +453,7 @@ public:
 
           // Extra
           {"fn", key_code::vk_fn_modifier},
+          {"hyper", key_code::vk_hyper_modifier}, // equals to ctrl + option + cmd
           {"vk_none", key_code::vk_none},
           {"vk_consumer_brightness_down", key_code::vk_consumer_brightness_down},
           {"vk_consumer_brightness_up", key_code::vk_consumer_brightness_up},
@@ -690,6 +695,7 @@ public:
       map[key_code(kHIDUsage_KeyboardRightGUI)] = 0x36;
 
       map[key_code::vk_fn_modifier] = 0x3f;
+      map[key_code::vk_hyper_modifier] = 0x84;
       map[key_code::vk_dashboard] = 0x82;
       map[key_code::vk_launchpad] = 0x83;
       map[key_code::vk_mission_control] = 0xa0;


### PR DESCRIPTION
Create a fake hyper key that user can map to.
E.x. `"left_control" : "hyper"`. Then when user click on `left_control + b`, it will be equivalent to `left_control + left_option + left_command + b`
