### PR TITLE
Add example for switching § and `

### DIFF
--- a/examples/switch_grave_accent_and_tilde_and_backslash.json
+++ b/examples/switch_grave_accent_and_tilde_and_backslash.json
@@ -1,0 +1,12 @@
+{
+    "profiles": [
+        {
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": {
+                "non_us_backslash": "grave_accent_and_tilde",
+                "grave_accent_and_tilde" : "non_us_backslash"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
It's in the usage/README.md as a popular example but not not in the examples directory