### PR TITLE
set keyboard_type (ansi, iso, jis) function implemented.

### DIFF
--- a/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
+++ b/src/apps/PreferencesWindow/PreferencesWindow/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1108" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
         <capability name="box content view" minToolsVersion="7.0"/>
@@ -564,7 +564,7 @@
                                             <rect key="frame" x="17" y="8" width="720" height="422"/>
                                             <clipView key="contentView" id="LCo-MQ-oMD">
                                                 <rect key="frame" x="1" y="0.0" width="718" height="421"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="26" rowSizeStyle="automatic" headerView="RPX-X6-Et1" viewBased="YES" id="OWP-Cf-tc8">
                                                         <rect key="frame" x="0.0" y="0.0" width="718" height="398"/>
@@ -690,14 +690,14 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="20" rowSizeStyle="automatic" headerView="PyG-O0-i8x" viewBased="YES" id="W1W-Xd-0KJ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="718" height="398"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="725" height="398"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
-                                                            <tableColumn identifier="DevicesCheckboxColumn" width="396" minWidth="40" maxWidth="10000" id="zRy-dI-ooE">
+                                                            <tableColumn identifier="DevicesCheckboxColumn" width="300" minWidth="40" maxWidth="10000" id="zRy-dI-ooE">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Modify events from this device">
                                                                     <font key="font" metaFont="smallSystem"/>
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
@@ -711,7 +711,7 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="DevicesCheckboxCellView" id="Kba-PK-fRo" customClass="DevicesTableCellView">
-                                                                        <rect key="frame" x="1" y="1" width="396" height="20"/>
+                                                                        <rect key="frame" x="1" y="1" width="300" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <button translatesAutoresizingMaskIntoConstraints="NO" id="vJd-Z6-vgS">
@@ -732,6 +732,42 @@
                                                                     </tableCellView>
                                                                 </prototypeCellViews>
                                                             </tableColumn>
+                                                            <tableColumn identifier="DevicesKeyboardTypeColumn" width="100" minWidth="10" maxWidth="3.4028234663852886e+38" id="msd-Ug-Tz3" userLabel="Keyboard Type">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Keyboard Type">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="UHe-Tk-cdW">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <prototypeCellViews>
+                                                                    <tableCellView identifier="DevicesKeyboardTypeCellView" id="MVJ-EV-V5i" customClass="DevicesTableCellView">
+                                                                        <rect key="frame" x="304" y="1" width="100" height="17"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <subviews>
+                                                                            <popUpButton verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="t6c-Ur-EgJ">
+                                                                                <rect key="frame" x="0.0" y="-4" width="100" height="26"/>
+                                                                                <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="bkI-kF-I39">
+                                                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                                                    <font key="font" metaFont="menu"/>
+                                                                                    <menu key="menu" id="6YC-sS-8RY"/>
+                                                                                </popUpButtonCell>
+                                                                            </popUpButton>
+                                                                        </subviews>
+                                                                        <constraints>
+                                                                            <constraint firstItem="t6c-Ur-EgJ" firstAttribute="centerX" secondItem="MVJ-EV-V5i" secondAttribute="centerX" id="D13-VN-keI"/>
+                                                                            <constraint firstItem="t6c-Ur-EgJ" firstAttribute="centerY" secondItem="MVJ-EV-V5i" secondAttribute="centerY" id="pno-1J-xo1"/>
+                                                                        </constraints>
+                                                                        <connections>
+                                                                            <outlet property="popUpButton" destination="t6c-Ur-EgJ" id="E9C-lt-klW"/>
+                                                                        </connections>
+                                                                    </tableCellView>
+                                                                </prototypeCellViews>
+                                                            </tableColumn>
                                                             <tableColumn identifier="DevicesVendorIdColumn" width="80" minWidth="40" maxWidth="1000" id="ErT-Oq-jVJ">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Vendor ID">
                                                                     <font key="font" metaFont="smallSystem"/>
@@ -746,7 +782,7 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="DevicesVendorIdCellView" id="Z95-LG-Bup">
-                                                                        <rect key="frame" x="400" y="1" width="80" height="20"/>
+                                                                        <rect key="frame" x="407" y="1" width="80" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="KQL-99-hgu">
@@ -783,7 +819,7 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="DevicesProductIdCellView" id="9WU-po-fh5">
-                                                                        <rect key="frame" x="483" y="1" width="80" height="20"/>
+                                                                        <rect key="frame" x="490" y="1" width="80" height="20"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="uPk-gc-Whv">
@@ -820,13 +856,13 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView identifier="DevicesTypeCellView" id="lW8-0s-DRR">
-                                                                        <rect key="frame" x="566" y="1" width="150" height="17"/>
+                                                                        <rect key="frame" x="573" y="1" width="150" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="TSO-R6-LPy">
-                                                                                <rect key="frame" x="0.0" y="2" width="139" height="14"/>
+                                                                                <rect key="frame" x="0.0" y="2" width="138" height="14"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="keyboard,pointing_device" id="KST-RC-Vwm">
-                                                                                    <font key="font" metaFont="system" size="11"/>
+                                                                                    <font key="font" metaFont="smallSystem"/>
                                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                                 </textFieldCell>
@@ -850,8 +886,8 @@
                                                     </tableView>
                                                 </subviews>
                                             </clipView>
-                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="WAQ-P3-E7u">
-                                                <rect key="frame" x="1" y="406" width="718" height="15"/>
+                                            <scroller key="horizontalScroller" verticalHuggingPriority="750" horizontal="YES" id="WAQ-P3-E7u">
+                                                <rect key="frame" x="1" y="405" width="718" height="16"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="D9Y-Xk-rU2">
@@ -859,7 +895,7 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <tableHeaderView key="headerView" id="PyG-O0-i8x">
-                                                <rect key="frame" x="0.0" y="0.0" width="718" height="23"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="725" height="23"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
@@ -1013,14 +1049,14 @@
                                         <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T7K-bf-5ph">
                                             <rect key="frame" x="17" y="48" width="720" height="382"/>
                                             <clipView key="contentView" id="h3K-SC-sFn">
-                                                <rect key="frame" x="1" y="1" width="703" height="380"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <rect key="frame" x="1" y="1" width="718" height="380"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <textView editable="NO" importsGraphics="NO" richText="NO" findStyle="panel" id="vyq-xs-cqF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="703" height="380"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="718" height="380"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                        <size key="minSize" width="703" height="380"/>
+                                                        <size key="minSize" width="718" height="380"/>
                                                         <size key="maxSize" width="720" height="10000000"/>
                                                         <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                     </textView>

--- a/src/apps/PreferencesWindow/PreferencesWindow/CoreConfigurationModel.h
+++ b/src/apps/PreferencesWindow/PreferencesWindow/CoreConfigurationModel.h
@@ -7,6 +7,7 @@
 
 @property(readonly) DeviceIdentifiers* deviceIdentifiers;
 @property BOOL ignore;
+@property uint32_t keyboardType;
 
 @end
 
@@ -27,6 +28,6 @@
 
 - (void)replaceFnFunctionKey:(NSString*)from to:(NSString*)to;
 
-- (void)setDeviceIgnore:(BOOL)ignore deviceIdentifiers:(DeviceIdentifiers*)deviceIdentifiers;
+- (void)setDeviceConfiguration:(DeviceIdentifiers*)deviceIdentifiers ignore:(BOOL)ignore keyboardType:(uint32_t) keyboardType;
 
 @end

--- a/src/apps/PreferencesWindow/PreferencesWindow/CoreConfigurationModel.m
+++ b/src/apps/PreferencesWindow/PreferencesWindow/CoreConfigurationModel.m
@@ -47,6 +47,7 @@
           DeviceConfiguration* deviceConfiguration = [DeviceConfiguration new];
           deviceConfiguration.deviceIdentifiers = deviceIdentifiers;
           deviceConfiguration.ignore = [device[@"ignore"] boolValue];
+          deviceConfiguration.keyboardType = [device[@"keyboard_type"] unsignedIntValue];
           [devices addObject:deviceConfiguration];
         }
       }
@@ -114,12 +115,13 @@
   self.fnFunctionKeys = fnFunctionKeys;
 }
 
-- (void)setDeviceIgnore:(BOOL)ignore deviceIdentifiers:(DeviceIdentifiers*)deviceIdentifiers {
+- (void)setDeviceConfiguration:(DeviceIdentifiers*)deviceIdentifiers ignore:(BOOL)ignore keyboardType:(uint32_t) keyboardType {
   NSMutableArray* devices = [NSMutableArray arrayWithArray:self.devices];
   BOOL __block found = NO;
   [devices enumerateObjectsUsingBlock:^(DeviceConfiguration* obj, NSUInteger index, BOOL* stop) {
     if ([obj.deviceIdentifiers isEqualToDeviceIdentifiers:deviceIdentifiers]) {
       obj.ignore = ignore;
+      obj.keyboardType = keyboardType;
 
       found = YES;
       *stop = YES;
@@ -130,6 +132,7 @@
     DeviceConfiguration* deviceConfiguration = [DeviceConfiguration new];
     deviceConfiguration.deviceIdentifiers = deviceIdentifiers;
     deviceConfiguration.ignore = ignore;
+    deviceConfiguration.keyboardType = keyboardType;
     [devices addObject:deviceConfiguration];
   }
 
@@ -164,6 +167,7 @@
     [array addObject:@{
       @"identifiers" : [d.deviceIdentifiers toDictionary],
       @"ignore" : @(d.ignore),
+      @"keyboard_type": @(d.keyboardType),
     }];
   }
   return array;

--- a/src/apps/PreferencesWindow/PreferencesWindow/DeviceModel.h
+++ b/src/apps/PreferencesWindow/PreferencesWindow/DeviceModel.h
@@ -29,6 +29,7 @@
 @property(readonly) DeviceIdentifiers* deviceIdentifiers;
 @property(readonly) DeviceDescriptions* deviceDescriptions;
 @property(readonly) BOOL ignore;
+@property(readonly) uint32_t keyboardType;
 
 - (instancetype)initWithDictionary:(NSDictionary*)dictionary;
 

--- a/src/apps/PreferencesWindow/PreferencesWindow/DeviceModel.m
+++ b/src/apps/PreferencesWindow/PreferencesWindow/DeviceModel.m
@@ -73,6 +73,7 @@
 @property(readwrite) DeviceIdentifiers* deviceIdentifiers;
 @property(readwrite) DeviceDescriptions* deviceDescriptions;
 @property(readwrite) BOOL ignore;
+@property(readwrite) uint32_t keyboardType;
 
 @end
 
@@ -85,6 +86,7 @@
     _deviceIdentifiers = [[DeviceIdentifiers alloc] initWithDictionary:device[@"identifiers"]];
     _deviceDescriptions = [[DeviceDescriptions alloc] initWithDictionary:device[@"descriptions"]];
     _ignore = [device[@"ignore"] boolValue];
+    _keyboardType = [device[@"keyboard_type"] unsignedIntValue];
   }
 
   return self;

--- a/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableCellView.h
+++ b/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableCellView.h
@@ -6,6 +6,7 @@
 @interface DevicesTableCellView : NSTableCellView
 
 @property(weak) IBOutlet NSButton* checkbox;
+@property(weak) IBOutlet NSPopUpButton* popUpButton;
 @property DeviceIdentifiers* deviceIdentifiers;
 
 @end

--- a/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableViewController.m
+++ b/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableViewController.m
@@ -35,8 +35,9 @@
 
 - (void)valueChanged:(id)sender {
   NSInteger row = [self.tableView rowForView:sender];
-  DevicesTableCellView* cellView = [self.tableView viewAtColumn:0 row:row makeIfNecessary:NO];
-  [self.configurationManager.configurationCoreModel setDeviceIgnore:(cellView.checkbox.state != NSOnState) deviceIdentifiers:cellView.deviceIdentifiers];
+  DevicesTableCellView* cellViewCheckbox = [self.tableView viewAtColumn:0 row:row makeIfNecessary:NO];
+  DevicesTableCellView* cellViewPopUp = [self.tableView viewAtColumn:1 row:row makeIfNecessary:NO];
+  [self.configurationManager.configurationCoreModel setDeviceConfiguration: cellViewCheckbox.deviceIdentifiers ignore:(cellViewCheckbox.checkbox.state != NSOnState) keyboardType: [cellViewPopUp.popUpButton.selectedItem.representedObject intValue]];
   [self.configurationManager save];
 }
 

--- a/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableViewDelegate.m
+++ b/src/apps/PreferencesWindow/PreferencesWindow/DevicesTableViewDelegate.m
@@ -11,6 +11,8 @@
 @property(weak) IBOutlet DeviceManager* deviceManager;
 @property(weak) IBOutlet DevicesTableViewController* devicesTableViewController;
 
+- (void) createKeyboardTypeMenu: (NSPopUpButton*) popUpButton keyboardType:(uint32_t) keyboardType;
+
 @end
 
 @implementation DevicesTableViewDelegate
@@ -38,6 +40,14 @@
       return result;
     }
 
+    if ([tableColumn.identifier isEqualToString:@"DevicesKeyboardTypeColumn"]) {
+      DevicesTableCellView* result = [tableView makeViewWithIdentifier:@"DevicesKeyboardTypeCellView" owner:self];
+      result.popUpButton.action = @selector(valueChanged:);
+      result.popUpButton.target = self.devicesTableViewController;
+      [self createKeyboardTypeMenu: result.popUpButton keyboardType:deviceModels[row].keyboardType];
+      return result;
+    }
+    
     if ([tableColumn.identifier isEqualToString:@"DevicesVendorIdColumn"]) {
       NSTableCellView* result = [tableView makeViewWithIdentifier:@"DevicesVendorIdCellView" owner:self];
       result.textField.stringValue = [NSString stringWithFormat:@"0x%04x", deviceModels[row].deviceIdentifiers.vendorId];
@@ -68,6 +78,47 @@
   }
 
   return nil;
+}
+
+- (void) createKeyboardTypeMenu:  (NSPopUpButton*) popUpButton keyboardType:(uint32_t) keyboardType {
+  popUpButton.menu = [NSMenu new];
+  NSMenuItem* item0 = [[NSMenuItem alloc] initWithTitle:@"default"
+                                                  action:NULL
+                                           keyEquivalent:@""];
+  item0.representedObject = [NSNumber numberWithInt:0];
+  [popUpButton.menu addItem:item0];
+  NSMenuItem* item40 = [[NSMenuItem alloc] initWithTitle:@"ansi"
+                                                action:NULL
+                                         keyEquivalent:@""];
+  item40.representedObject = [NSNumber numberWithInt:40];
+  [popUpButton.menu addItem:item40];
+  NSMenuItem* item41 = [[NSMenuItem alloc] initWithTitle:@"iso"
+                                                  action:NULL
+                                           keyEquivalent:@""];
+  item41.representedObject = [NSNumber numberWithInt:41];
+  [popUpButton.menu addItem:item41];
+  NSMenuItem* item42 = [[NSMenuItem alloc] initWithTitle:@"jis"
+                                                  action:NULL
+                                           keyEquivalent:@""];
+  item42.representedObject = [NSNumber numberWithInt:42];
+  [popUpButton.menu addItem:item42];
+
+  if(keyboardType == 0){
+    [popUpButton selectItem:item0];
+  }else if(keyboardType == 40){
+    [popUpButton selectItem:item40];
+  }else if(keyboardType == 41){
+    [popUpButton selectItem:item41];
+  }else if(keyboardType == 42){
+    [popUpButton selectItem:item42];
+  }else{
+    NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:@"type:%d", keyboardType]
+                                                    action:NULL
+                                             keyEquivalent:@""];
+    item.representedObject = [NSNumber numberWithInt:keyboardType];
+    [popUpButton.menu addItem:item];
+    [popUpButton selectItem:item];
+  }
 }
 
 @end

--- a/src/core/console_user_server/include/configuration_manager.hpp
+++ b/src/core/console_user_server/include/configuration_manager.hpp
@@ -53,8 +53,8 @@ private:
     }
 
     grabber_client_.clear_devices();
-    for (const auto& pair: core_configuration_->get_current_profile_devices()) {
-      grabber_client_.add_device(pair.first, pair.second);
+    for (const auto& tuple: core_configuration_->get_current_profile_devices()) {
+      grabber_client_.add_device(std::get<0>(tuple), std::get<1>(tuple), std::get<2>(tuple));
     }
     grabber_client_.complete_devices();
   }

--- a/src/core/event_dispatcher/include/receiver.hpp
+++ b/src/core/event_dispatcher/include/receiver.hpp
@@ -91,7 +91,7 @@ private:
             logger::get_logger().error("invalid size for krbn::operation_type::post_modifier_flags");
           } else {
             auto p = reinterpret_cast<krbn::operation_type_post_modifier_flags_struct*>(&(buffer_[0]));
-            hid_system_client_.post_modifier_flags(p->key_code, p->flags);
+            hid_system_client_.post_modifier_flags(p->key_code, p->flags, p->keyboard_type);
           }
           break;
 
@@ -100,7 +100,7 @@ private:
             logger::get_logger().error("invalid size for krbn::operation_type::post_key");
           } else {
             auto p = reinterpret_cast<krbn::operation_type_post_key_struct*>(&(buffer_[0]));
-            hid_system_client_.post_key(p->key_code, p->event_type, p->flags, p->repeat);
+            hid_system_client_.post_key(p->key_code, p->event_type, p->flags, p->repeat, p->keyboard_type);
           }
           break;
 

--- a/src/core/grabber/include/manipulator/event_dispatcher_manager.hpp
+++ b/src/core/grabber/include/manipulator/event_dispatcher_manager.hpp
@@ -84,7 +84,7 @@ public:
     }
   }
 
-  void post_modifier_flags(krbn::key_code key_code, IOOptionBits flags) {
+  void post_modifier_flags(krbn::key_code key_code, IOOptionBits flags, krbn::keyboard_type keyboard_type) {
     std::lock_guard<std::mutex> guard(client_mutex_);
 
     if (!client_) {
@@ -96,13 +96,14 @@ public:
       krbn::operation_type_post_modifier_flags_struct s;
       s.key_code = key_code;
       s.flags = flags;
+      s.keyboard_type = keyboard_type;
       client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
     } catch (...) {
       client_ = nullptr;
     }
   }
 
-  void post_key(krbn::key_code key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat) {
+  void post_key(krbn::key_code key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat, krbn::keyboard_type keyboard_type) {
     std::lock_guard<std::mutex> guard(client_mutex_);
 
     if (!client_) {
@@ -116,6 +117,7 @@ public:
       s.event_type = event_type;
       s.flags = flags;
       s.repeat = repeat;
+      s.keyboard_type = keyboard_type;
       client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
     } catch (...) {
       client_ = nullptr;

--- a/src/core/grabber/include/manipulator/event_manipulator.hpp
+++ b/src/core/grabber/include/manipulator/event_manipulator.hpp
@@ -129,7 +129,7 @@ public:
     virtual_hid_manager_client_ = nullptr;
   }
 
-  void handle_keyboard_event(device_registry_entry_id device_registry_entry_id, krbn::key_code from_key_code, bool pressed) {
+  void handle_keyboard_event(device_registry_entry_id device_registry_entry_id, krbn::key_code from_key_code, bool pressed, krbn::keyboard_type keyboard_type) {
     krbn::key_code to_key_code = from_key_code;
 
     // ----------------------------------------
@@ -220,12 +220,12 @@ public:
       return;
     }
 
-    if (post_modifier_flag_event(to_key_code, pressed)) {
+    if (post_modifier_flag_event(to_key_code, pressed, keyboard_type)) {
       key_repeat_manager_.stop();
       return;
     }
 
-    post_key(from_key_code, to_key_code, pressed, false);
+    post_key(from_key_code, to_key_code, pressed, false, keyboard_type);
 
     // set key repeat
     long initial_key_repeat_milliseconds = 0;
@@ -237,7 +237,7 @@ public:
     }
 
     key_repeat_manager_.start(from_key_code, to_key_code, pressed,
-                              initial_key_repeat_milliseconds, key_repeat_milliseconds);
+                              initial_key_repeat_milliseconds, key_repeat_milliseconds, keyboard_type);
   }
 
   void handle_pointing_event(device_registry_entry_id device_registry_entry_id,
@@ -414,7 +414,7 @@ private:
     }
 
     void start(krbn::key_code from_key_code, krbn::key_code to_key_code, bool pressed,
-               long initial_key_repeat_milliseconds, long key_repeat_milliseconds) {
+               long initial_key_repeat_milliseconds, long key_repeat_milliseconds, krbn::keyboard_type keyboard_type) {
       // stop key repeat before post key.
       if (pressed) {
         stop();
@@ -437,7 +437,7 @@ private:
             key_repeat_milliseconds * NSEC_PER_MSEC,
             0,
             ^{
-              event_manipulator_.post_key(from_key_code, to_key_code, pressed, true);
+              event_manipulator_.post_key(from_key_code, to_key_code, pressed, true, keyboard_type);
             });
 
         from_key_code_ = from_key_code;
@@ -456,7 +456,7 @@ private:
     boost::optional<krbn::key_code> from_key_code_;
   };
 
-  bool post_modifier_flag_event(krbn::key_code key_code, bool pressed) {
+  bool post_modifier_flag_event(krbn::key_code key_code, bool pressed, krbn::keyboard_type keyboard_type) {
     auto operation = pressed ? manipulator::modifier_flag_manager::operation::increase : manipulator::modifier_flag_manager::operation::decrease;
 
     auto modifier_flag = krbn::types::get_modifier_flag(key_code);
@@ -464,7 +464,7 @@ private:
       modifier_flag_manager_.manipulate(modifier_flag, operation);
 
       auto flags = modifier_flag_manager_.get_io_option_bits(key_code);
-      event_dispatcher_manager_.post_modifier_flags(key_code, flags);
+      event_dispatcher_manager_.post_modifier_flags(key_code, flags, keyboard_type);
 
       return true;
     }
@@ -481,13 +481,13 @@ private:
     }
   }
 
-  void post_key(krbn::key_code from_key_code, krbn::key_code to_key_code, bool pressed, bool repeat) {
+  void post_key(krbn::key_code from_key_code, krbn::key_code to_key_code, bool pressed, bool repeat, krbn::keyboard_type keyboard_type) {
     auto hid_system_key = krbn::types::get_hid_system_key(to_key_code);
     auto hid_system_aux_control_button = krbn::types::get_hid_system_aux_control_button(to_key_code);
     if (hid_system_key || hid_system_aux_control_button) {
       auto event_type = pressed ? krbn::event_type::key_down : krbn::event_type::key_up;
       auto flags = modifier_flag_manager_.get_io_option_bits(to_key_code);
-      event_dispatcher_manager_.post_key(to_key_code, event_type, flags, repeat);
+      event_dispatcher_manager_.post_key(to_key_code, event_type, flags, repeat, keyboard_type);
     }
   }
 

--- a/src/core/grabber/include/receiver.hpp
+++ b/src/core/grabber/include/receiver.hpp
@@ -143,7 +143,7 @@ private:
             logger::get_logger().error("invalid size for krbn::operation_type::add_device ({0})", n);
           } else {
             auto p = reinterpret_cast<krbn::operation_type_add_device_struct*>(&(buffer_[0]));
-            device_grabber_.add_device_configuration(p->device_identifiers_struct, p->ignore);
+            device_grabber_.add_device_configuration(p->device_identifiers_struct, p->ignore, p->keyboard_type);
           }
           break;
 

--- a/src/share/core_configuration.hpp
+++ b/src/share/core_configuration.hpp
@@ -40,6 +40,7 @@
 //                         "is_pointing_device": false
 //                     },
 //                     "ignore": false
+//                     "keyboard_type": 0
 //                 },
 //                 {
 //                     "identifiers": {
@@ -49,6 +50,7 @@
 //                         "is_pointing_device": false
 //                     },
 //                     "ignore": true
+//                     "keyboard_type": 45
 //                 }
 //             ]
 //         },
@@ -101,8 +103,8 @@ public:
     return get_key_code_pair_from_json_object(profile["fn_function_keys"]);
   }
 
-  std::vector<std::pair<krbn::device_identifiers_struct, bool>> get_current_profile_devices(void) {
-    std::vector<std::pair<krbn::device_identifiers_struct, bool>> v;
+  std::vector<std::tuple<krbn::device_identifiers_struct, bool, krbn::keyboard_type>> get_current_profile_devices(void) {
+    std::vector<std::tuple<krbn::device_identifiers_struct, bool, krbn::keyboard_type>> v;
 
     auto profile = get_current_profile();
     if (profile["devices"].is_array()) {
@@ -118,7 +120,8 @@ public:
           s.product_id = krbn::product_id(static_cast<uint32_t>(device["identifiers"]["product_id"]));
           s.is_keyboard = device["identifiers"]["is_keyboard"];
           s.is_pointing_device = device["identifiers"]["is_pointing_device"];
-          v.push_back(std::make_pair(s, device["ignore"]));
+          krbn::keyboard_type keyboard_type = device["keyboard_type"].is_number() ? krbn::keyboard_type(static_cast<uint32_t>(device["keyboard_type"])) : krbn::keyboard_type::none;
+          v.push_back(std::make_tuple(s, device["ignore"], keyboard_type));
         }
       }
     }

--- a/src/share/grabber_client.hpp
+++ b/src/share/grabber_client.hpp
@@ -72,10 +72,11 @@ public:
     client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
   }
 
-  void add_device(const krbn::device_identifiers_struct& device_identifiers_struct, bool ignore) {
+  void add_device(const krbn::device_identifiers_struct& device_identifiers_struct, bool ignore, krbn::keyboard_type keyboard_type) {
     krbn::operation_type_add_device_struct s;
     s.device_identifiers_struct = device_identifiers_struct;
     s.ignore = ignore;
+    s.keyboard_type = keyboard_type;
     client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
   }
 

--- a/src/share/hid_system_client.hpp
+++ b/src/share/hid_system_client.hpp
@@ -49,10 +49,11 @@ public:
     }
   }
 
-  void post_modifier_flags(krbn::key_code key_code, IOOptionBits flags) {
+  void post_modifier_flags(krbn::key_code key_code, IOOptionBits flags, krbn::keyboard_type keyboard_type) {
     if (auto key = krbn::types::get_hid_system_key(key_code)) {
       NXEventData event{};
       event.key.keyCode = *key;
+      event.key.keyboardType = static_cast<uint32_t>(keyboard_type);
 
       IOGPoint loc{};
       post_event(NX_FLAGSCHANGED, loc, &event, kNXEventDataVersion, flags, kIOHIDSetGlobalEventFlags);
@@ -63,21 +64,21 @@ public:
     logger_.warn("key_code:{1:#x} is unsupported key @ {0}", __PRETTY_FUNCTION__, static_cast<uint32_t>(key_code));
   }
 
-  void post_key(krbn::key_code key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat) {
+  void post_key(krbn::key_code key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat, krbn::keyboard_type keyboard_type) {
     if (auto key = krbn::types::get_hid_system_aux_control_button(key_code)) {
       post_aux_control_button(*key, event_type, flags, repeat);
       return;
     }
 
     if (auto key = krbn::types::get_hid_system_key(key_code)) {
-      post_key(*key, event_type, flags, repeat);
+      post_key(*key, event_type, flags, repeat, keyboard_type);
       return;
     }
 
     logger_.warn("key_code:{1:#x} is unsupported key @ {0}", __PRETTY_FUNCTION__, static_cast<uint32_t>(key_code));
   }
 
-  void post_key(uint8_t key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat) {
+  void post_key(uint8_t key_code, krbn::event_type event_type, IOOptionBits flags, bool repeat, krbn::keyboard_type keyboard_type) {
     NXEventData event{};
     event.key.origCharCode = 0;
     event.key.repeat = repeat;
@@ -85,7 +86,8 @@ public:
     event.key.charCode = 0;
     event.key.keyCode = key_code;
     event.key.origCharSet = NX_ASCIISET;
-    event.key.keyboardType = 0;
+    event.key.keyboardType = static_cast<uint32_t>(keyboard_type);
+
 
     IOGPoint loc{};
     post_event(event_type == krbn::event_type::key_down ? NX_KEYDOWN : NX_KEYUP,

--- a/src/share/types.hpp
+++ b/src/share/types.hpp
@@ -219,7 +219,8 @@ struct device_identifiers_struct {
   bool is_pointing_device;
 };
 
-enum class keyboard_type {
+enum class keyboard_type : uint32_t {
+  none = 0,
   ansi = 40,
   iso = 41,
   jis = 42,
@@ -790,6 +791,7 @@ struct operation_type_add_device_struct {
   const operation_type operation_type;
   device_identifiers_struct device_identifiers_struct;
   bool ignore;
+  keyboard_type keyboard_type;
 };
 
 struct operation_type_complete_devices_struct {
@@ -824,6 +826,7 @@ struct operation_type_post_modifier_flags_struct {
   const operation_type operation_type;
   key_code key_code;
   IOOptionBits flags;
+  keyboard_type keyboard_type;
 };
 
 struct operation_type_post_key_struct {
@@ -834,5 +837,6 @@ struct operation_type_post_key_struct {
   event_type event_type;
   IOOptionBits flags;
   bool repeat;
+  keyboard_type keyboard_type;
 };
 }


### PR DESCRIPTION
Hello Mr. takezo,

Thank you for your very convenient tool. I'm using your tool since KeyRemap4MacBook.

 I encountered a problem that my JIS keyboard wrongly recognized as ANSI keyboard. I was using this keyboard with Karabiner's `__SetKeyboardType__ KeyboardType::JIS_MACBOOK_2008` option. So I implemented almost same function on Karabiner-Element, and I confirmed it works in my case.

 It seems keyboard layout problem is common, so I think this modification may be useful for other people too. If you think this modification is appropriate, please merge this into your source tree.

- Modified Preferences App
![image](https://cloud.githubusercontent.com/assets/1322178/19789190/bfea5588-9ce8-11e6-8cd1-b1e659a2d6d2.png)

- karabiner.json
![image](https://cloud.githubusercontent.com/assets/1322178/19789206/dd1d2f90-9ce8-11e6-94e7-946511b875a7.png)

- probably related issues
  - JIS external keyboard recognized as US (ASCII) keyboard after v0.90.47 #278
  - Built-in and external keyboard differs #229
  - Wrong keyboard layout used (english, instead of german) #323

Thank you,