### PR TITLE
Explicitly call out usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Karabiner-Elements works fine.
 
 You can download the latest Karabiner-Elements from https://pqrs.org/latest/karabiner-elements-latest.dmg
 
-# [Usage](usage/README.md)
+# Usage
+
+Detailed usage instructions are available [here](usage/README.md).
 
 ## Features
 


### PR DESCRIPTION
I think it's easy to overlook the fact that the README's usage heading is a link to a separate document (I know I missed it for a while).  I thought explicitly calling out the separate document would make it easier to see.