### PR TITLE
Example JSON: opening new windows of applications via json shell_command

### DIFF
--- a/examples/launch_Chrome_and_iTerm2_new_windows_keybindings.json
+++ b/examples/launch_Chrome_and_iTerm2_new_windows_keybindings.json
@@ -1,0 +1,60 @@
+{
+    "profiles": [
+        {
+            "complex_modifications": {
+                "parameters": {
+                    "basic.to_if_alone_timeout_milliseconds": 1000
+                },
+                "rules": [
+                    {
+                        "description": "Lcontrol Lshift backtick = new terminal",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "grave_accent_and_tilde",
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "left_control",
+                                            "left_shift"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "shell_command": "osascript -e 'tell app \"iTerm2\"' -e 'create window with default profile' -e activate -e end"
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Lcontrol Lshift 1 = new Chrome",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "1",
+                                    "modifiers": {
+                                        "mandatory": [
+                                            "left_control",
+                                            "left_shift"
+                                        ]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "shell_command": "osascript -e 'tell app \"Google Chrome\"' -e 'make new window' -e activate -e end"
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": {}
+        }
+    ]
+}


### PR DESCRIPTION
This JSON example lets you open a new iTerm2 window via "left control, left shift, and `"  or a new Chrome window via "left control, left shift, and 1", using the new shell_command in the complex modifications json element.  (The ability to launch new windows, and not just applications, via keyboard bindings is much harder on Mac than Linux, and may be useful for recent converts like me trying to salvage their old Linux habits via Karabiner).