### PR TITLE
Add qwerty_to_workman.json to examples

### DIFF
--- a/examples/qwerty_to_workman.json
+++ b/examples/qwerty_to_workman.json
@@ -1,0 +1,32 @@
+{
+    "profiles": [
+        {
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": {
+                "caps_lock": "delete_or_backspace",
+                 "w": "d",
+                 "e": "r",
+                 "r": "w",
+                 "t": "b",
+                 "y": "j",
+                 "u": "f",
+                 "i": "u",
+                 "o": "p",
+                 "p": "semicolon",
+                 "d": "h",
+                 "f": "t",
+                 "h": "y",
+                 "j": "n",
+                 "k": "e",
+                 "l": "o",
+                 "semicolon": "i",
+                 "c": "m",
+                 "v": "c",
+                 "b": "v",
+                 "n": "k",
+                 "m": "l"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Lately I have been pretty inspired to start learning the [workman] keyboard
layout. This commit adds an example file for mapping the standard qwerty
layout to the workman layout.

[workman]:https://viralintrospection.wordpress.com/2010/09/06/a-different-philosophy-in-designing-keyboard-layouts/