### PR TITLE
Feature/refactor bash scripts

### DIFF
--- a/scripts/build-and-install.sh
+++ b/scripts/build-and-install.sh
@@ -7,7 +7,7 @@ readonly TOPDIR=`dirname $0`/..
 main() {
     cd "$TOPDIR"
 
-    # remove macports include paths
+    # Remove macports include paths
     unset CPATH
 
     if [ "$1" != "--no-rebase" ]; then

--- a/scripts/build-and-install.sh
+++ b/scripts/build-and-install.sh
@@ -1,31 +1,37 @@
-#!/bin/bash
-
-topdir=`dirname $0`/..
-cd "$topdir"
+#!/usr/bin/env bash
 
 set -e
 
-# remove macports include paths
-unset CPATH
+readonly TOPDIR=`dirname $0`/..
 
-if [ "$1" != "--no-rebase" ]; then
-    git pull --rebase
-fi
+main() {
+    cd "$TOPDIR"
 
-make
+    # remove macports include paths
+    unset CPATH
 
-DMG=$(ls *.dmg)
+    if [ "$1" != "--no-rebase" ]; then
+        git pull --rebase
+    fi
 
-VOL=`hdiutil attach "$DMG" | grep -o "/Volumes/.*"`
+    make
 
-echo
-echo -ne '\033[33;40m'
-echo "========================================"
-echo "Trying to install `basename $DMG .dmg` with administrator privilege."
-echo "Please enter your password in order to run 'sudo installer ...' command."
-echo "========================================"
-echo -ne '\033[0m'
-echo
+    DMG=$(ls *.dmg)
 
-sudo installer -package "$VOL"/*.pkg -target /
-hdiutil detach "$VOL"
+    VOL=`hdiutil attach "$DMG" | grep -o "/Volumes/.*"`
+
+    echo
+    echo -ne '\033[33;40m'
+    echo "========================================"
+    echo "Trying to install `basename $DMG .dmg` with administrator privilege."
+    echo "Please enter your password in order to run 'sudo installer ...' command."
+    echo "========================================"
+    echo -ne '\033[0m'
+    echo
+
+    sudo installer -package "$VOL"/*.pkg -target /
+    hdiutil detach "$VOL"
+}
+
+main
+

--- a/scripts/build-and-install.sh
+++ b/scripts/build-and-install.sh
@@ -32,5 +32,5 @@ main() {
     hdiutil detach "$VOL"
 }
 
-main
+main "$1"
 

--- a/scripts/build-and-install.sh
+++ b/scripts/build-and-install.sh
@@ -17,7 +17,6 @@ main() {
     make
 
     DMG=$(ls *.dmg)
-
     VOL=`hdiutil attach "$DMG" | grep -o "/Volumes/.*"`
 
     echo

--- a/scripts/codesign-pkg.sh
+++ b/scripts/codesign-pkg.sh
@@ -1,25 +1,33 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-CODESIGN_IDENTITY='79E265756C43F62E157DB5C8FA405B54428653F9'
+set -e
 
-# ------------------------------------------------------------
-PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
+readonly CODESIGN_IDENTITY='79E265756C43F62E157DB5C8FA405B54428653F9'
+readonly PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
+readonly LOGFILE="`dirname $0`/productsign.log"
 
-if [ ! -e "$1" ]; then
-    echo "[ERROR] Invalid argument: '$1'"
-    exit 1
-fi
+err() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+}
 
-# ------------------------------------------------------------
-# sign
-logfile="`dirname $0`/productsign.log"
-if 1>"$logfile" 2>&1 productsign --sign "$CODESIGN_IDENTITY" "$1" "$1".signed; then
-    cat $logfile
-    mv "$1".signed "$1"
-else
-    echo -ne '\033[31;40m'
-    cat $logfile
-    echo -ne '\033[0m'
-fi
-rm -f "$logfile"
-rm -f "$1".signed
+main() {
+    if [ ! -e "$1" ]; then
+        err "Invalid argument: '$1'"
+        exit 1
+    fi
+
+    # Sign with CODESIGN_IDENTITY
+    if 1>"$LOGFILE" 2>&1 productsign --sign "$CODESIGN_IDENTITY" "$1" "$1".signed; then
+        cat $LOGFILE
+        mv "$1".signed "$1"
+    else
+        echo -ne '\033[31;40m'
+        cat "$LOGFILE"
+        echo -ne '\033[0m'
+    fi
+    rm -f "$LOGFILE"
+    rm -f "$1".signed
+}
+
+main "$1"
+

--- a/scripts/codesign-pkg.sh
+++ b/scripts/codesign-pkg.sh
@@ -16,7 +16,7 @@ main() {
         exit 1
     fi
 
-    # Sign with CODESIGN_IDENTITY
+    # Sign with codesign
     if 1>"$LOGFILE" 2>&1 productsign --sign "$CODESIGN_IDENTITY" "$1" "$1".signed; then
         cat $LOGFILE
         mv "$1".signed "$1"

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -1,35 +1,43 @@
 #!/bin/bash
 
-CODESIGN_IDENTITY='8ECD43BA902B40380BD84C4512385E6C5EB3F160'
+set -e
 
-# ------------------------------------------------------------
-PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
+readonly CODESIGN_IDENTITY='8ECD43BA902B40380BD84C4512385E6C5EB3F160'
+readonly PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
 
-if [ ! -e "$1" ]; then
-    echo "[ERROR] Invalid argument: '$1'"
-    exit 1
-fi
+err() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+}
 
-# ------------------------------------------------------------
-# sign
-cd "$1"
-find * -name '*.app' -or -path '*/bin/*' | sort -r | while read f; do
-    echo -ne '\033[33;40m'
-    echo "code sign $f"
-    echo -ne '\033[0m'
+main() {
+    if [ ! -e "$1" ]; then
+        err "Invalid argument: '$1'"
+        exit 1
+    fi
 
-    echo -ne '\033[31;40m'
-    codesign \
-        --force \
-        --deep \
-        --sign "$CODESIGN_IDENTITY" \
-        "$f"
-    echo -ne '\033[0m'
-done
+    # Sign with codesign
+    cd "$1"
+    find * -name '*.app' -or -path '*/bin/*' | sort -r | while read f; do
+        echo -ne '\033[33;40m'
+        echo "code sign $f"
+        echo -ne '\033[0m'
 
-# verify
-find * -name '*.app' -or -path '*/bin/*' | sort -r | while read f; do
-    echo -ne '\033[31;40m'
-    codesign --verify --deep "$f"
-    echo -ne '\033[0m'
-done
+        echo -ne '\033[31;40m'
+        codesign \
+            --force \
+            --deep \
+            --sign "$CODESIGN_IDENTITY" \
+            "$f"
+        echo -ne '\033[0m'
+    done
+
+    # Verify codesign
+    find * -name '*.app' -or -path '*/bin/*' | sort -r | while read f; do
+        echo -ne '\033[31;40m'
+        codesign --verify --deep "$f"
+        echo -ne '\033[0m'
+    done
+}
+
+main "$1"
+

--- a/scripts/reduce-logs.rb
+++ b/scripts/reduce-logs.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 command=ARGV[0]
 

--- a/scripts/setpermissions.sh
+++ b/scripts/setpermissions.sh
@@ -1,40 +1,49 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
+set -e
 
-if [ ! -e "$1" ]; then
-    echo "[ERROR] Invalid argument: '$1'"
-    exit 1
-fi
+readonly PATH=/bin:/sbin:/usr/bin:/usr/sbin; export PATH
 
-# ------------------------------------------------------------
+err() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+}
+
 test_mach_o() {
     if `file -b "$1" | grep 'executable ' | grep -sq 'Mach-O '`; then
         # This is Mach-O file.
-
-        # except kext bundle
+        # Except kext bundle
         if `file -b "$1" | grep -sq 'kext bundle'`; then
             exit 1
         fi
 
         exit 0
     fi
+
     exit 1
 }
 
-# ------------------------------------------------------------
-find "$1" -print0 | while read -d $'\0' filepath; do
-    if [ -d "$filepath" ]; then
-        chmod -h 755 "$filepath"
-    else
-        extension=${filepath##*.}
-        if [ "$extension" = 'sh' ]; then
-            chmod -h 755 "$filepath"
-        elif `test_mach_o "$filepath"`; then
-            # preserve the set-user-ID-on-execution bits.
-            chmod -h u+rwx,go=rx "$filepath"
-        else
-            chmod -h 644 "$filepath"
-        fi
+main() {
+    if [ ! -e "$1" ]; then
+        err "Invalid argument: '$1'"
+        exit 1
     fi
-done
+    
+    find "$1" -print0 | while read -d $'\0' filepath; do
+        if [ -d "$filepath" ]; then
+            chmod -h 755 "$filepath"
+        else
+            extension=${filepath##*.}
+            if [ "$extension" = 'sh' ]; then
+                chmod -h 755 "$filepath"
+            elif `test_mach_o "$filepath"`; then
+                # Preserve the set-user-ID-on-execution bits.
+                chmod -h u+rwx,go=rx "$filepath"
+            else
+                chmod -h 644 "$filepath"
+            fi
+        fi
+    done
+}
+
+main "$1"
+

--- a/scripts/setversion.sh
+++ b/scripts/setversion.sh
@@ -1,19 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-basedir=`dirname $0`
-version=$(cat "$basedir/../version")
+set -e
 
-find $basedir/.. \( -name 'Info.plist.tmpl' -or -name 'Distribution.xml.tmpl' \) -print0 | while IFS= read -r -d '' f; do
-    if [ -f "$f" ]; then
-        outputfile=`dirname "$f"`/`basename "$f" .tmpl`
-        tmpfile=`mktemp /tmp/Info.plist.XXXXXX`
+readonly BASEDIR=`dirname $0`
+readonly VERSION=$(cat "$BASEDIR/../VERSION")
 
-        sed "s|PKGVERSION|$version|g" "$f" > $tmpfile
-        if cmp -s "$tmpfile" "$outputfile"; then
-            # tmpfile and outputfile are same. remove tmpfile.
-            rm -f "$tmpfile"
-        else
-            mv "$tmpfile" "$outputfile"
+main() {
+    find $BASEDIR/.. \( -name 'Info.plist.tmpl' -or -name 'Distribution.xml.tmpl' \) -print0 | while IFS= read -r -d '' f; do
+        if [ -f "$f" ]; then
+            outputfile=`dirname "$f"`/`basename "$f" .tmpl`
+            tmpfile=`mktemp /tmp/Info.plist.XXXXXX`
+
+            sed "s|PKGVERSION|$VERSION|g" "$f" > $tmpfile
+            if cmp -s "$tmpfile" "$outputfile"; then
+                # tmpfile and outputfile are same. remove tmpfile.
+                rm -f "$tmpfile"
+            else
+                mv "$tmpfile" "$outputfile"
+            fi
         fi
-    fi
-done
+    done
+}
+
+main
+


### PR DESCRIPTION
- Refactor to follow conventions
- Change shebangs to #!/usr/bin/env <SHELL>
- Use main function
- Add readonly to constant variables and make them in uppercase as well
- Use bash instead of the inferior sh