### PR TITLE
`set_inputsource` to change current input source

### DIFF
--- a/appendix/dump_hid_value/main.cpp
+++ b/appendix/dump_hid_value/main.cpp
@@ -189,6 +189,10 @@ private:
         case krbn::event_queue::queued_event::event::type::set_variable:
           std::cout << "set_variable" << std::endl;
           break;
+
+        case krbn::event_queue::queued_event::event::type::set_inputsource:
+          std::cout << "set_inputsource" << std::endl;
+          break;
       }
     }
 

--- a/src/core/console_user_server/include/receiver.hpp
+++ b/src/core/console_user_server/include/receiver.hpp
@@ -4,6 +4,8 @@
 #include "constants.hpp"
 #include "local_datagram_server.hpp"
 #include "shell_utility.hpp"
+#include "cf_utility.hpp"
+#include "inputsources.hpp"
 #include "types.hpp"
 #include <vector>
 
@@ -67,6 +69,22 @@ private:
               std::string background_shell_command = shell_utility::make_background_command(p->shell_command);
               dispatch_async(dispatch_get_main_queue(), ^{
                 system(background_shell_command.c_str());
+              });
+            }
+            break;
+
+          case operation_type::set_inputsource:
+            if (n != sizeof(operation_type_set_inputsource_struct)) {
+              logger::get_logger().error("invalid size for operation_type::set_inputsource");
+            } else {
+              auto p = reinterpret_cast<operation_type_set_inputsource_struct*>(&(buffer_[0]));
+              
+              // Ensure inputsource_id is null-terminated string even if corrupted data is sent.
+              p->inputsource_id[sizeof(p->inputsource_id) - 1] = '\0';
+              auto inputsource_id(p->inputsource_id);
+              
+              dispatch_async(dispatch_get_main_queue(), ^{
+                inputsources::select(inputsource_id);
               });
             }
             break;

--- a/src/core/console_user_server/karabiner_console_user_server.xcodeproj/project.pbxproj
+++ b/src/core/console_user_server/karabiner_console_user_server.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		34DA28A11D8FA4A40029E37D /* file_monitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = file_monitor.hpp; sourceTree = "<group>"; };
 		34E9F62E1D2134770007AE90 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		34F4D5171E647EAD007D5065 /* configuration_monitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = configuration_monitor.hpp; sourceTree = "<group>"; };
+		7C95EC091F7E91BE00D3E523 /* inputsources.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = inputsources.hpp; sourceTree = "<group>"; };
+		7C95EC0A1F7E91E700D3E523 /* cf_utility.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cf_utility.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,8 @@
 		3495C6801D3CE652007CB9E7 /* share */ = {
 			isa = PBXGroup;
 			children = (
+				7C95EC0A1F7E91E700D3E523 /* cf_utility.hpp */,
+				7C95EC091F7E91BE00D3E523 /* inputsources.hpp */,
 				344608C31E3E5DE4007956BD /* application_launcher.hpp */,
 				345AC0051D621651009D1FB4 /* boost_defs.hpp */,
 				34F4D5171E647EAD007D5065 /* configuration_monitor.hpp */,

--- a/src/core/grabber/include/manipulator/manipulator_manager.hpp
+++ b/src/core/grabber/include/manipulator/manipulator_manager.hpp
@@ -77,6 +77,7 @@ public:
         case event_queue::queued_event::event::type::pointing_vertical_wheel:
         case event_queue::queued_event::event::type::pointing_horizontal_wheel:
         case event_queue::queued_event::event::type::shell_command:
+        case event_queue::queued_event::event::type::set_inputsource:
           for (auto&& m : manipulators_) {
             m->manipulate(front_input_event,
                           input_event_queue,

--- a/src/core/grabber/karabiner_grabber.xcodeproj/project.pbxproj
+++ b/src/core/grabber/karabiner_grabber.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		34E9F62E1D2134770007AE90 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		34EED7101D6FA38400399AD1 /* apple_hid_usage_tables.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = apple_hid_usage_tables.hpp; sourceTree = "<group>"; };
 		34EED7111D6FA38C00399AD1 /* human_interface_device.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = human_interface_device.hpp; sourceTree = "<group>"; };
+		7C95EC081F7DBE5F00D3E523 /* inputsources.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = inputsources.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,6 +150,7 @@
 				3469EB701D814F140005D30D /* filesystem.hpp */,
 				3431346E1DB70C900008F284 /* gcd_utility.hpp */,
 				34EED7111D6FA38C00399AD1 /* human_interface_device.hpp */,
+				7C95EC081F7DBE5F00D3E523 /* inputsources.hpp */,
 				341F59DC1D5778A000B441A8 /* iokit_utility.hpp */,
 				3431346C1DB3CD8A0008F284 /* iopm_client.hpp */,
 				34A88A941D68446C00DD480B /* karabiner_version.h */,

--- a/src/share/cf_utility.hpp
+++ b/src/share/cf_utility.hpp
@@ -81,4 +81,93 @@ public:
                                      &kCFTypeDictionaryValueCallBacks);
   }
 };
+  
+class cf_string final {
+public:
+  cf_string(): value_(nullptr) {
+  }
+
+  cf_string(const _Nullable CFStringRef& s, bool retain) {
+    value_ = s;
+    if (retain && value_ != nullptr)
+      CFRetain(value_);
+  }
+
+  cf_string(const std::string& s) {
+    value_ = CFStringCreateWithCString(kCFAllocatorDefault, s.c_str(), kCFStringEncodingUTF8);
+  }
+  
+  cf_string(const cf_string& s) {
+    value_ = s.value_;
+    CFRetain(value_);
+  }
+  
+  ~cf_string() {
+    if (value_ != nullptr)
+      CFRelease(value_);
+  }
+  
+  cf_string& operator=(const cf_string& s) {
+    if (value_ != nullptr)
+      CFRelease(value_);
+
+    value_ = s.value_;
+    if (value_ != nullptr)
+      CFRetain(value_);
+    
+    return *this;
+  }
+  
+  cf_string& operator=(const std::string& s) {
+    if (value_ != nullptr)
+      CFRelease(value_);
+    
+    value_ = CFStringCreateWithCString(kCFAllocatorDefault, s.c_str(), kCFStringEncodingUTF8);
+    
+    return *this;
+  }
+  
+  inline _Nullable CFStringRef get() const {
+    return value_;
+  }
+  
+private:
+  _Nullable CFStringRef value_;
+};
+  
+inline bool operator==(const cf_string& lhs, const cf_string& rhs) {
+  if (lhs.get() == nullptr || rhs.get() == nullptr)
+    return lhs.get() == rhs.get();
+  return CFStringCompare(lhs.get(), rhs.get(), 0) == 0;
+}
+
+inline bool operator==(const _Nullable CFStringRef& lhs, const cf_string& rhs) {
+  if (lhs == nullptr || rhs.get() == nullptr)
+    return lhs == rhs.get();
+  return CFStringCompare(lhs, rhs.get(), 0) == 0;
+}
+
+inline bool operator==(const cf_string& lhs, const _Nullable CFStringRef& rhs) {
+  if (lhs.get() == nullptr || rhs == nullptr)
+    return lhs.get() == rhs;
+  return CFStringCompare(lhs.get(), rhs, 0) == 0;
+}
+
+inline bool operator!=(const cf_string& lhs, const cf_string& rhs) {
+  if (lhs.get() == nullptr || rhs.get() == nullptr)
+    return lhs.get() != rhs.get();
+  return CFStringCompare(lhs.get(), rhs.get(), 0) != 0;
+}
+
+inline bool operator!=(const _Nullable CFStringRef& lhs, const cf_string& rhs) {
+  if (lhs == nullptr || rhs.get() == nullptr)
+    return lhs != rhs.get();
+  return CFStringCompare(lhs, rhs.get(), 0) != 0;
+}
+
+inline bool operator!=(const cf_string& lhs, const _Nullable CFStringRef& rhs) {
+  if (lhs.get() == nullptr || rhs == NULL)
+    return lhs.get() != rhs;
+  return CFStringCompare(lhs.get(), rhs, 0) != 0;
+}
 } // namespace krbn

--- a/src/share/console_user_server_client.hpp
+++ b/src/share/console_user_server_client.hpp
@@ -46,6 +46,21 @@ public:
     client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
   }
 
+  void set_inputsource(const std::string& inputsource_id) {
+    operation_type_set_inputsource_struct s;
+    
+    if (inputsource_id.length() >= sizeof(s.inputsource_id)) {
+      logger::get_logger().error("shell_command is too long: {0}", inputsource_id);
+      return;
+    }
+    
+    strlcpy(s.inputsource_id,
+            inputsource_id.c_str(),
+            sizeof(s.inputsource_id));
+    
+    client_->send_to(reinterpret_cast<uint8_t*>(&s), sizeof(s));
+  }
+  
   static std::string make_console_user_server_socket_directory(uid_t uid) {
     std::stringstream ss;
     ss << constants::get_console_user_server_socket_directory() << "/" << uid;

--- a/src/share/event_queue.hpp
+++ b/src/share/event_queue.hpp
@@ -34,6 +34,7 @@ public:
         event_from_ignored_device,
         frontmost_application_changed,
         set_variable,
+        set_inputsource,
       };
 
       event(key_code key_code) : type_(type::key_code),
@@ -88,6 +89,13 @@ public:
         event e;
         e.type_ = type::set_variable;
         e.value_ = pair;
+        return e;
+      }
+
+      static event make_set_inputsource_event(const std::string& inputsource_id) {
+        event e;
+        e.type_ = type::set_inputsource;
+        e.value_ = inputsource_id;
         return e;
       }
 
@@ -157,6 +165,13 @@ public:
         return boost::none;
       }
 
+      boost::optional<std::string> get_set_inputsource(void) const {
+        if (type_ == type::set_inputsource) {
+          return boost::get<std::string>(value_);
+        }
+        return boost::none;
+      }
+
       bool operator==(const event& other) const {
         return get_type() == other.get_type() &&
                value_ == other.value_;
@@ -204,7 +219,7 @@ public:
                      consumer_key_code, // For type::consumer_key_code
                      pointing_button,   // For type::pointing_button
                      int64_t,           // For type::pointing_x, type::pointing_y, type::pointing_vertical_wheel, type::pointing_horizontal_wheel
-                     std::string,       // For shell_command
+                     std::string,       // For shell_command, set_inputsource
                      boost::blank,      // For virtual events
                      frontmost_application,
                      std::pair<std::string, int> // For set_variable

--- a/src/share/inputsources.hpp
+++ b/src/share/inputsources.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "boost_defs.hpp"
+#include <Carbon/Carbon.h>
+
+namespace krbn {
+class inputsources final {
+public:
+  static void select(const std::string& id) {
+    cf_string new_inputsource_id(id);
+    auto found = false;
+    
+    auto inputsources = TISCreateInputSourceList(NULL, false);
+    auto count = CFArrayGetCount(inputsources);
+    
+    for (auto i = 0; i < count; ++i) {
+      auto inputsource = (TISInputSourceRef)CFArrayGetValueAtIndex(inputsources, i);
+      auto inputsource_id = (CFStringRef)TISGetInputSourceProperty(inputsource, kTISPropertyInputSourceID);
+      
+      if (inputsource_id == new_inputsource_id) {
+        OSStatus status = TISSelectInputSource(inputsource);
+        if (status != noErr)
+          logger::get_logger().error("inputsources::select: {0}, failed: {1}", id, status);
+        found = true;
+        break;
+      }
+    }
+    
+    if (!found) {
+      std::stringstream ss;
+      for (auto i = 0; i < count; ++i) {
+        auto inputsource = (TISInputSourceRef)CFArrayGetValueAtIndex(inputsources, i);
+        auto inputsource_id = * cf_utility::to_string((CFStringRef)TISGetInputSourceProperty(inputsource, kTISPropertyInputSourceID));
+        if (i > 0)
+          ss << ", ";
+        ss << '"' << inputsource_id << '"';
+      }
+      logger::get_logger().error("inputsources::select: {0}, no source found among available [{1}]", id, ss.str());
+    }
+
+    CFRelease(inputsources);
+  }
+};
+} // namespace krbn

--- a/src/share/types.hpp
+++ b/src/share/types.hpp
@@ -32,6 +32,7 @@ enum class operation_type : uint8_t {
   frontmost_application_changed,
   // grabber -> console_user_server
   shell_command_execution,
+  set_inputsource,
 };
 
 enum class device_id : uint32_t {
@@ -1094,6 +1095,13 @@ struct operation_type_shell_command_execution_struct {
 
   const operation_type operation_type;
   char shell_command[256];
+};
+
+struct operation_type_set_inputsource_struct {
+  operation_type_set_inputsource_struct(void) : operation_type(operation_type::set_inputsource) {}
+
+  const operation_type operation_type;
+  char inputsource_id[256];
 };
 
 // stream output

--- a/tests/src/event_definition/test.cpp
+++ b/tests/src/event_definition/test.cpp
@@ -610,7 +610,20 @@ TEST_CASE("manipulator.details.to_event_definition") {
     REQUIRE(event_definition.get_type() == krbn::manipulator::details::event_definition::type::shell_command);
     REQUIRE(event_definition.get_key_code() == boost::none);
     REQUIRE(event_definition.get_pointing_button() == boost::none);
+    REQUIRE(event_definition.get_set_inputsource() == boost::none);
     REQUIRE(event_definition.get_shell_command() == shell_command);
+  }
+  {
+    std::string inputsource_id = "com.apple.keylayout.US";
+    nlohmann::json json({
+        {"set_inputsource", inputsource_id},
+    });
+    krbn::manipulator::details::to_event_definition event_definition(json);
+    REQUIRE(event_definition.get_type() == krbn::manipulator::details::event_definition::type::set_inputsource);
+    REQUIRE(event_definition.get_key_code() == boost::none);
+    REQUIRE(event_definition.get_pointing_button() == boost::none);
+    REQUIRE(event_definition.get_shell_command() == boost::none);
+    REQUIRE(event_definition.get_set_inputsource() == inputsource_id);
   }
 }
 

--- a/tests/src/post_event_to_virtual_devices/test.cpp
+++ b/tests/src/post_event_to_virtual_devices/test.cpp
@@ -521,6 +521,9 @@ public:
         case post_event_to_virtual_devices::queue::event::type::shell_command:
           events.push_back(post_event_to_virtual_devices::queue::event::make_shell_command_event(*(e.get_shell_command()), 0));
           break;
+        case post_event_to_virtual_devices::queue::event::type::set_inputsource:
+          events.push_back(post_event_to_virtual_devices::queue::event::make_set_inputsource_event(*(e.get_set_inputsource()), 0));
+          break;
       }
     }
     return events;


### PR DESCRIPTION
Added `set_inputsource` event, with value should contain input source id, like `com.apple.keylayout.US`

Example of usage:
```js
{
    "title": "Input source selection",
    "rules": [{
        "description": "Cmd_L for US, Cmd_R for RU, if pressed alone",
        "manipulators": [{
            "type": "basic",
            "from": {
                "key_code": "left_command",
                "modifiers": {"optional": ["any"]}
            },
            "to": [{"key_code": "left_command"}],
            "to_if_alone": [{"set_inputsource": "com.apple.keylayout.US"}]
        }, {
            "type": "basic",
            "from": {
                "key_code": "right_command",
                "modifiers": {"optional": ["any"]}
            },
            "to": [{"key_code": "right_command"}],
            "to_if_alone": [{"set_inputsource": "com.apple.keylayout.RussianWin"}]
        }]
    }]
}
```