### PR TITLE
add "halt" boolean to consume event

### DIFF
--- a/src/core/grabber/include/manipulator/details/types.hpp
+++ b/src/core/grabber/include/manipulator/details/types.hpp
@@ -494,6 +494,7 @@ class to_event_definition final {
 public:
   to_event_definition(const nlohmann::json& json) : lazy_(false),
                                                     repeat_(true),
+                                                    halt_(true),
                                                     hold_down_milliseconds_(0) {
     if (!json.is_object()) {
       logger::get_logger().error("complex_modifications json error: Invalid form of to_event_definition: {0}", json.dump());
@@ -532,6 +533,17 @@ public:
         }
 
         repeat_ = value;
+
+        continue;
+      }
+
+      if (key == "halt") {
+        if (!value.is_boolean()) {
+          logger::get_logger().error("complex_modifications json error: Invalid form of halt: {0}", json.dump());
+          continue;
+        }
+
+        halt_ = value;
 
         continue;
       }
@@ -589,6 +601,10 @@ public:
     return repeat_;
   }
 
+  bool get_halt(void) const {
+    return halt_;
+  }
+
   int get_hold_down_milliseconds(void) const {
     return hold_down_milliseconds_;
   }
@@ -626,6 +642,7 @@ private:
   std::unordered_set<modifier_definition::modifier> modifiers_;
   bool lazy_;
   bool repeat_;
+  bool halt_;
   int hold_down_milliseconds_;
 };
 


### PR DESCRIPTION
Is this a useful idea for you?  (I'm sure the implementation needs work, and I haven't yet tried to understand the test suite.)

The purpose is for a "to" event entry to be able to fully consume the input event.  After `"halt": true`. no other "to" events will fire.  `halt` is only respected on the last event of a series.

My usecase is holding down a key.  When pressing the key normally I want the normal single keystroke to be sent, which I do with `to_after_key_up`.  When holding down the key I want a precise double-tap to be sent.  Without this patch I could not work out a configuration that would reliably send exactly two keystrokes for the double-tap.

My configuration for using this looks like

```json
{
    "title": "Emacs Hold Control-Q to double-tap",
    "rules": [
        {
            "description": "Emacs: translate Hold-Control-Q to fast double-tap.",
            "manipulators": [
                {
                    "type": "basic",
                    "conditions": [
                        {
                            "type": "frontmost_application_if",
                            "bundle_identifiers": [
                                "^org\\.gnu\\.Emacs$"
                            ]
                        }
                    ],
                    "from": {
                        "key_code": "q",
                        "modifiers": {
                            "mandatory": [
                                "control"
                            ]
                        }
                    },
                    "to_after_key_up": [
                        {
                            "key_code": "q",
                            "modifiers": ["control"],
                            "repeat": false
                        }
                    ],
                    "to_if_held_down": [
                        {
                            "key_code": "q",
                            "modifiers": ["control"]
                        },
                        {
                            "key_code": "q",
                            "modifiers": ["control"],
                            "repeat": false,
                            "halt": true
                        }
                    ]
                }
            ]
        }
    ]
}
```