### PR TITLE
Increase the number of entries shown in the event viewer queue

### DIFF
--- a/src/apps/EventViewer/src/EventQueue.m
+++ b/src/apps/EventViewer/src/EventQueue.m
@@ -77,7 +77,7 @@ static void hid_value_observer_callback(enum libkrbn_hid_value_type type,
 @implementation EventQueue
 
 enum {
-  MAXNUM = 50,
+  MAXNUM = 256,
 };
 
 - (instancetype)init {


### PR DESCRIPTION
Increase the number of entries shown in the event viewer queue.

Considering that modifiers and up-down events usually mean there are at least 2 entries per keypress, often more, this change increases the number of events shown to make the event viewer more useful.