### PR TITLE
Correction to TRAVIS badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/tekezo/Karabiner-Elements.svg?branch=master)](https://travis-ci.org/tekezo/Karabiner-Elements)
+[![Build Status](https://travis-ci.com/tekezo/Karabiner-Elements.svg?branch=master)](https://travis-ci.com/tekezo/Karabiner-Elements)
 [![License](https://img.shields.io/badge/license-Public%20Domain-blue.svg)](https://github.com/tekezo/Karabiner-Elements/blob/master/LICENSE.md)
 
 # Karabiner-Elements


### PR DESCRIPTION
.com instead of .org
https://travis-ci.com/tekezo/Karabiner-Elements.svg?branch=master